### PR TITLE
gNMI String to Number Conversion Option

### DIFF
--- a/plugins/inputs/cisco_telemetry_gnmi/README.md
+++ b/plugins/inputs/cisco_telemetry_gnmi/README.md
@@ -33,6 +33,9 @@ It has been optimized to support GNMI telemetry as produced by Cisco IOS XR (64-
 
   ## attempt to parse strings to numbers (uint64, int64, float64)
   # parse_string_number = true
+  ## parse all numbers only to float64
+  ## resolves uint64/int64/float64 data type issues at cost of precision
+  # parse_string_number_as_floats = true
 
   ## GNMI subscription prefix (optional, can usually be left empty)
   ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths

--- a/plugins/inputs/cisco_telemetry_gnmi/README.md
+++ b/plugins/inputs/cisco_telemetry_gnmi/README.md
@@ -31,6 +31,9 @@ It has been optimized to support GNMI telemetry as produced by Cisco IOS XR (64-
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
+  ## attempt to parse strings to numbers (uint64, int64, float64)
+  # parse_string_number = true
+
   ## GNMI subscription prefix (optional, can usually be left empty)
   ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
   # origin = ""

--- a/plugins/inputs/cisco_telemetry_gnmi/cisco_telemetry_gnmi_test.go
+++ b/plugins/inputs/cisco_telemetry_gnmi/cisco_telemetry_gnmi_test.go
@@ -105,20 +105,35 @@ func TestWaitError(t *testing.T) {
 
 // Tests the behavior of ParseStringToNumber and defaulting to Uint64 as data type.
 func TestParseStringToNumber(t *testing.T) {
-	assert.Equal(t, uint64(math.MaxUint64), parseStringNumber(strconv.FormatUint(math.MaxUint64, 10)))
-	assert.Equal(t, uint64(math.MaxUint32), parseStringNumber(strconv.FormatUint(math.MaxUint32, 10)))
-	assert.Equal(t, uint64(math.MaxInt64), parseStringNumber(strconv.FormatInt(math.MaxInt64, 10)))
-	assert.Equal(t, uint64(math.MaxInt32), parseStringNumber(strconv.FormatInt(math.MaxInt32, 10)))
-	assert.Equal(t, int64(math.MinInt64), parseStringNumber(strconv.FormatInt(math.MinInt64, 10)))
-	assert.Equal(t, int64(math.MinInt32), parseStringNumber(strconv.FormatInt(math.MinInt32, 10)))
-	assert.Equal(t, float64(math.MaxFloat64), parseStringNumber(strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)))
-	assert.Equal(t, float64(math.MaxFloat32), parseStringNumber(strconv.FormatFloat(math.MaxFloat32, 'E', -1, 64)))
+	assert.Equal(t, uint64(math.MaxUint64), parseStringNumber(strconv.FormatUint(math.MaxUint64, 10), false))
+	assert.Equal(t, uint64(math.MaxUint32), parseStringNumber(strconv.FormatUint(math.MaxUint32, 10), false))
+	assert.Equal(t, uint64(math.MaxInt64), parseStringNumber(strconv.FormatInt(math.MaxInt64, 10), false))
+	assert.Equal(t, uint64(math.MaxInt32), parseStringNumber(strconv.FormatInt(math.MaxInt32, 10), false))
+	assert.Equal(t, int64(math.MinInt64), parseStringNumber(strconv.FormatInt(math.MinInt64, 10), false))
+	assert.Equal(t, int64(math.MinInt32), parseStringNumber(strconv.FormatInt(math.MinInt32, 10), false))
+	assert.Equal(t, float64(math.MaxFloat64), parseStringNumber(strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64), false))
+	assert.Equal(t, float64(math.MaxFloat32), parseStringNumber(strconv.FormatFloat(math.MaxFloat32, 'E', -1, 64), false))
 	// Uncertain if this is really valid, but negative max?
-	assert.Equal(t, float64(math.MaxFloat64*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat64*-1, 'E', -1, 64)))
-	assert.Equal(t, float64(math.MaxFloat32*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat32*-1, 'E', -1, 64)))
-	assert.Equal(t, float64(1234.567), parseStringNumber("1234.567"))
-	assert.Equal(t, float64(-1234.567), parseStringNumber("-1234.567"))
-	assert.Equal(t, "hello1234!", parseStringNumber("hello1234!"))
+	assert.Equal(t, float64(math.MaxFloat64*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat64*-1, 'E', -1, 64), false))
+	assert.Equal(t, float64(math.MaxFloat32*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat32*-1, 'E', -1, 64), false))
+	assert.Equal(t, float64(1234.567), parseStringNumber("1234.567", false))
+	assert.Equal(t, float64(-1234.567), parseStringNumber("-1234.567", false))
+	assert.Equal(t, "hello1234!", parseStringNumber("hello1234!", false))
+	// Now test everything as float
+	assert.Equal(t, float64(math.MaxUint64), parseStringNumber(strconv.FormatUint(math.MaxUint64, 10), true))
+	assert.Equal(t, float64(math.MaxUint32), parseStringNumber(strconv.FormatUint(math.MaxUint32, 10), true))
+	assert.Equal(t, float64(math.MaxInt64), parseStringNumber(strconv.FormatInt(math.MaxInt64, 10), true))
+	assert.Equal(t, float64(math.MaxInt32), parseStringNumber(strconv.FormatInt(math.MaxInt32, 10), true))
+	assert.Equal(t, float64(math.MinInt64), parseStringNumber(strconv.FormatInt(math.MinInt64, 10), true))
+	assert.Equal(t, float64(math.MinInt32), parseStringNumber(strconv.FormatInt(math.MinInt32, 10), true))
+	assert.Equal(t, float64(math.MaxFloat64), parseStringNumber(strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64), true))
+	assert.Equal(t, float64(math.MaxFloat32), parseStringNumber(strconv.FormatFloat(math.MaxFloat32, 'E', -1, 64), true))
+	// Uncertain if this is really valid, but negative max?
+	assert.Equal(t, float64(math.MaxFloat64*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat64*-1, 'E', -1, 64), true))
+	assert.Equal(t, float64(math.MaxFloat32*-1), parseStringNumber(strconv.FormatFloat(math.MaxFloat32*-1, 'E', -1, 64), true))
+	assert.Equal(t, float64(1234.567), parseStringNumber("1234.567", true))
+	assert.Equal(t, float64(-1234.567), parseStringNumber("-1234.567", true))
+	assert.Equal(t, "hello1234!", parseStringNumber("hello1234!", true))
 }
 
 func TestUsernamePassword(t *testing.T) {


### PR DESCRIPTION
Adds the option to attempt to convert strings within Update Values to `uint64`/`int64`/`float64`.
